### PR TITLE
Fixed typo in models

### DIFF
--- a/core/mobile_devices/models.py
+++ b/core/mobile_devices/models.py
@@ -47,5 +47,5 @@ class AbstractMobileDevice(models.Model):
         return True if self.push_device_type == self.APN else False
 
     @property
-    def ios_android(self):
+    def is_android(self):
         return True if self.push_device_type == self.GCM else False


### PR DESCRIPTION
Hi, very interesting project, I fixed a typo in the `is_android` property, replacing `ios_android`.